### PR TITLE
Emtpy metadata fix

### DIFF
--- a/lib.rb
+++ b/lib.rb
@@ -86,14 +86,16 @@ def diff(cf_data, uptime_data)
         diff_data["to_add"] << app_data
       else
         # Check is already in uptime, better check if we need to update it
-        uptime_check = uptime_data.select {|u| u["url"] == url}[0]
-        update_data = {}
-        update_data["alertTreshold"] = app["alertTreshold"] if app["alertTreshold"] != uptime_check["alertTreshold"] # alertTreshold is wrongly spelled in uptime.
-        update_data["interval"] = app["interval"] if app["interval"] != uptime_check["interval"]
-        update_data["tags"] = app["tags"] if Set.new(app["tags"]) != Set.new(uptime_check["tags"])
-        if not update_data.empty?
-          update_data["_id"] = uptime_check["_id"]
-          diff_data["to_update"] << update_data
+        if not app["empty_meta"] # If we for some reason failed to fetch the meta we dont want to update the check!
+          uptime_check = uptime_data.select {|u| u["url"] == url}[0]
+          update_data = {}
+          update_data["alertTreshold"] = app["alertTreshold"] if app["alertTreshold"] != uptime_check["alertTreshold"] # alertTreshold is wrongly spelled in uptime.
+          update_data["interval"] = app["interval"] if app["interval"] != uptime_check["interval"]
+          update_data["tags"] = app["tags"] if Set.new(app["tags"]) != Set.new(uptime_check["tags"])
+          if not update_data.empty?
+            update_data["_id"] = uptime_check["_id"]
+            diff_data["to_update"] << update_data
+          end
         end
       end
     end

--- a/lib.rb
+++ b/lib.rb
@@ -64,6 +64,7 @@ def create_app_data(app, meta_path, regex, alert_threshold, interval)
   app_data["alertTreshold"] = alert_treshold(meta, alert_threshold) # alertTreshold is wrongly spelled in uptime.
   app_data["interval"] = check_interval(meta, interval)
   app_data["tags"] = create_tags(app, meta)
+  app_data["empty_meta"] = true if meta.empty?
   app_data
 end
 

--- a/spec/test.rb
+++ b/spec/test.rb
@@ -137,6 +137,33 @@ describe 'create_app_data' do
       expect(create_app_data data, "/internal/status", /-live/, 1, 60).to eq(expected)
     end
   end
+
+  context 'when given a app where the fetching of metadata fails' do
+    it 'should return the app data with the ' do
+      stub_request(:get, /isrctn-live.domain.com/).
+        to_return(status: 404)
+
+      data = {
+        "org" => "isrctn",
+        "space" => "live",
+        "name"=> "isrctn-live-509",
+        "routes"=> [
+          "isrctn-live.domain.com",
+          "isrctn-live-509.domain.com"
+        ],
+        "data_from"=>1424103541
+      }
+
+      expected = {
+        "monitor_routes" => ["http://isrctn-live.domain.com/internal/status"],
+        "alertTreshold" => 1,  # keyword is misspelled in Uptime
+        "interval" => 60,
+        "tags" => ["isrctn"],
+        "empty_meta" => true
+      }
+      expect(create_app_data data, "/internal/status", /-live/, 1, 60).to eq(expected)
+    end
+  end
 end
 
 describe 'get_meta' do

--- a/spec/test.rb
+++ b/spec/test.rb
@@ -108,6 +108,20 @@ describe 'diff' do
       expect(diff_data).to eq expected
     end
   end
+
+  context 'when given cf data which have failed to fetch meta' do
+    it 'should not update the check' do
+      cf_data = [{"monitor_routes" => ["a"], "tags" => ["simon"], "empty_meta" => true}]
+      uptime_data = [{"_id" => "WRYYYYY", "url" => "a", "name" => "a", "tags" => ["simon", "johansson"]}]
+
+      diff_data = diff(cf_data, uptime_data)
+      expected = {"to_add" => [],
+                  "to_delete" => [],
+                  "to_update" => []}
+
+      expect(diff_data).to eq expected
+    end
+  end
 end
 
 describe 'create_app_data' do

--- a/spec/test.rb
+++ b/spec/test.rb
@@ -153,7 +153,7 @@ describe 'create_app_data' do
   end
 
   context 'when given a app where the fetching of metadata fails' do
-    it 'should return the app data with the ' do
+    it 'should return the app data with the emtpy_meta field set to true' do
       stub_request(:get, /isrctn-live.domain.com/).
         to_return(status: 404)
 


### PR DESCRIPTION
When we for some reason fail to fetch metadata the current diffing we carry between the cf data and the uptime data, will most likely differ so the check would be updated, which we do not want.

This fixes that.
